### PR TITLE
商品詳細表示機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@
 
 ## Items テーブル
 
-| column               | Type    | Options                                      |
-|----------------------|---------|----------------------------------------------|
-| name                 | string  | null: false                                  |
-| description          | text    | null: false                                  |
-| category             | integer | null: false                                  |
-| status               | integer | null: false                                  |
-| price                | integer | null: false                                  |
-| shipping_area        | integer | null: false                                  |
-| shipping_fee_burden  | integer | null: false                                  |
-| days_to_ship         | integer | null: false                                  |
-| user_id              | integer | null: false, foreign_key: :true              |
+| column                  | Type    | Options                                      |
+|-------------------------|---------|----------------------------------------------|
+| name                    | string  | null: false                                  |
+| description             | text    | null: false                                  |
+| category_id             | integer | null: false                                  |
+| status_id               | integer | null: false                                  |
+| price_id                | integer | null: false                                  |
+| shipping_area_id        | integer | null: false                                  |
+| shipping_fee_burden_id  | integer | null: false                                  |
+| days_to_ship_id         | integer | null: false                                  |
+| user_id                 | integer | null: false, foreign_key: :true              |
 
 ### Association
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :authenticate_user!, only: [:new]
   
   def index
     @items = Item.includes(:user).all.order("created_at DESC")

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.includes(:user).all.order("created_at DESC")
   end
   
   def new
@@ -9,7 +9,8 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id]) 
+    @show = Item.find_by(id: params[:id]) 
+    @user = User.find_by(id: @show.user_id)
   end
  
   def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,22 @@
 class ItemsController < ApplicationController
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :category, :days_to_ship, :shipping_area, :shipping_fee_burden, :status
+
   def index
     @items = Item.all.order("created_at DESC")
   end
   
   def new
     @item = Item.new
+  end
+
+  def show
+    @show = Item.find(params[:id]) 
+    @category = Category.all
+    @days_to_ship = Days_to_ship.all
+    @shipping_area = Shipping_area.all
+    @shipping_fee_burden = Shipping_fee_burden.all
+    @status = Status.all
   end
  
   def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,5 @@
 class ItemsController < ApplicationController
-  extend ActiveHash::Associations::ActiveRecordExtensions
-  belongs_to_active_hash :category, :days_to_ship, :shipping_area, :shipping_fee_burden, :status
-
+  
   def index
     @items = Item.all.order("created_at DESC")
   end
@@ -11,12 +9,7 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @show = Item.find(params[:id]) 
-    @category = Category.all
-    @days_to_ship = Days_to_ship.all
-    @shipping_area = Shipping_area.all
-    @shipping_fee_burden = Shipping_fee_burden.all
-    @status = Status.all
+    @item = Item.find(params[:id]) 
   end
  
   def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,7 +11,6 @@ class ItemsController < ApplicationController
 
   def show
     @show = Item.find_by(id: params[:id]) 
-    @user = User.find_by(id: @show.user_id)
   end
  
   def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,8 +26,9 @@ class ItemsController < ApplicationController
 
   private
   def item_params
-    params.require(:item).permit(:name, :image, :description, :category, :status, :shipping_fee_burden, :shipping_area, :days_to_ship, :price).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :name, :description, :category_id, :status_id, :shipping_fee_burden_id, :shipping_area_id, :days_to_ship_id, :price).merge(user_id: current_user.id)
   end
+
 end
 
 

--- a/app/models/days_to_ship.rb
+++ b/app/models/days_to_ship.rb
@@ -6,4 +6,5 @@ class DaysToShip < ActiveHash::Base
                {id: 2, name: '2~3日で発送'}, 
                {id: 3, name: '4~7日で発送'},
               ]
+
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,10 +5,9 @@ class Item < ApplicationRecord
   belongs_to_active_hash :shipping_area
   belongs_to_active_hash :shipping_fee_burden
   belongs_to_active_hash :status
-  belongs_to :user
   has_one    :purchase
   has_one_attached :image
-
+  belongs_to :user
   validate :image_presence
 
   def image_presence
@@ -21,11 +20,11 @@ class Item < ApplicationRecord
     end
   end
   validates :name, presence: true
-  validates :category, inclusion: { in: 1..10 }
-  validates :status, inclusion: { in: 1..6 }
-  validates :shipping_fee_burden, inclusion: { in: 1..2 }
-  validates :shipping_area, inclusion: { in: 1..47 }
-  validates :days_to_ship, inclusion: { in: 1..3 }
+  validates :category_id, inclusion: { in: 1..10 }
+  validates :status_id, inclusion: { in: 1..6 }
+  validates :shipping_fee_burden_id, inclusion: { in: 1..2 }
+  validates :shipping_area_id, inclusion: { in: 1..47 }
+  validates :days_to_ship_id, inclusion: { in: 1..3 }
   with_options presence: true do
     validates :price, format: {with: /\A[0-9]+\z/, message: "is invalid. Input half-width characters."}
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,10 @@
 class Item < ApplicationRecord
-
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :category
+  belongs_to_active_hash :days_to_ship
+  belongs_to_active_hash :shipping_area
+  belongs_to_active_hash :shipping_fee_burden
+  belongs_to_active_hash :status
   belongs_to :user
   has_one    :purchase
   has_one_attached :image

--- a/app/models/shipping_area.rb
+++ b/app/models/shipping_area.rb
@@ -18,4 +18,6 @@ class ShippingArea < ActiveHash::Base
                {id: 42, name: '長崎県'}, {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, 
                {id: 45, name: '宮崎県'}, {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
               ]
+
+              
 end

--- a/app/models/shipping_fee_burden.rb
+++ b/app/models/shipping_fee_burden.rb
@@ -6,4 +6,5 @@ class ShippingFeeBurden < ActiveHash::Base
                {id: 1, name: '着払い(購入者負担)'},
                {id: 2, name: '送料込み(出品者負担)'}, 
               ]
+
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -122,7 +122,7 @@
       
           <div class='item-img-content'>
             <% if set.image.attached? %>
-              <%= image_tag set.image, class: "item-img" %>
+              <%=link_to image_tag(set.image, class: "item-img"), item_path(set.id)%>
             <%end%>
             
               <%# 商品が売れていればsold outを表示しましょう %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -47,12 +47,12 @@
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:status, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
 
@@ -66,17 +66,17 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_fee_burden, ShippingFeeBurden.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_fee_burden_id, ShippingFeeBurden.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_area, ShippingArea.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:shipping_area_id, ShippingArea.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:days_to_ship, DaysToShip.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:days_to_ship_id, DaysToShip.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @show.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag item.image, class: 'item-box-img' if item.image.attached? %>
+      <%= image_tag @show.image, class: 'item-box-img' if @show.image.attached? %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @show.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -37,7 +37,7 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @show.description %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,6 +8,7 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @show.image, class: 'item-box-img' if @show.image.attached? %>
+     
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -24,10 +25,11 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+  <% if user_signed_in? && current_user.id == @show.user_id%>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+  <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= @show.name %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag @show.image, class: 'item-box-img' if @show.image.attached? %>
+      <%= image_tag @item.image, class: 'item-box-img' if @item.image.attached? %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,10 +16,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ <%= @show.price %>
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        (税込) 送料込み
+        (税込) <%= @item.shipping_fee_burden.name %>
       </span>
     </div>
 
@@ -37,33 +37,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= @show.description %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name  %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name  %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee_burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipping_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days_to_ship.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,16 +22,20 @@
         (税込) <%= @show.shipping_fee_burden.name %>
       </span>
     </div>
+    
+  <% if user_signed_in?%>
+    <% if user_signed_in? && current_user.id == @show.user_id%>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% end %>
 
-  <% if user_signed_in? && current_user.id == @show.user_id%>
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% if not current_user.id == @show.user_id%>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
   <% end %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
 
     <div class="item-explain-box">
       <span><%= @show.description %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -40,7 +40,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @user.nickname %></td>
+          <td class="detail-value"><%= @show.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
@@ -98,7 +98,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @show.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= @item.name %>
+      <%= @show.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag @item.image, class: 'item-box-img' if @item.image.attached? %>
+      <%= image_tag @show.image, class: 'item-box-img' if @show.image.attached? %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,10 +16,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ <%= @item.price %>
+        ¥ <%= @show.price %>
       </span>
       <span class="item-postage">
-        (税込) <%= @item.shipping_fee_burden.name %>
+        (税込) <%= @show.shipping_fee_burden.name %>
       </span>
     </div>
 
@@ -37,33 +37,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= @item.description %></span>
+      <span><%= @show.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.user.nickname %></td>
+          <td class="detail-value"><%= @user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= @item.category.name  %></td>
+          <td class="detail-value"><%= @show.category.name  %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= @item.status.name  %></td>
+          <td class="detail-value"><%= @show.status.name  %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= @item.shipping_fee_burden.name %></td>
+          <td class="detail-value"><%= @show.shipping_fee_burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= @item.shipping_area.name %></td>
+          <td class="detail-value"><%= @show.shipping_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= @item.days_to_ship.name %></td>
+          <td class="detail-value"><%= @show.days_to_ship.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,6 +1,5 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
@@ -24,7 +23,6 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
   <% if user_signed_in? && current_user.id == @show.user_id%>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
@@ -34,9 +32,6 @@
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @show.description %></span>
@@ -80,7 +75,6 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
 
   <div class="comment-box">
     <form>

--- a/db/migrate/20200917031711_create_items.rb
+++ b/db/migrate/20200917031711_create_items.rb
@@ -1,15 +1,15 @@
 class CreateItems < ActiveRecord::Migration[6.0]
   def change
     create_table :items do |t|
-      t.string  :name,                  null: false
-      t.text    :description,           null: false
-      t.integer :category,              null: false
-      t.integer :status,                null: false
-      t.integer :price,                 null: false
-      t.integer :shipping_area,         null: false
-      t.integer :shipping_fee_burden,   null: false
-      t.integer :days_to_ship,          null: false
-      t.integer :user_id,               null: false      
+      t.string  :name,                     null: false
+      t.text    :description,              null: false
+      t.integer :category_id,              null: false
+      t.integer :status_id,                null: false
+      t.integer :price,                    null: false
+      t.integer :shipping_area_id,         null: false
+      t.integer :shipping_fee_burden_id,   null: false
+      t.integer :days_to_ship_id,          null: false
+      t.integer :user_id,                  null: false      
       t.timestamps
     end
   end

--- a/db/migrate/20200920033237_add_item_to_items.rb
+++ b/db/migrate/20200920033237_add_item_to_items.rb
@@ -1,5 +1,0 @@
-class AddItemToItems < ActiveRecord::Migration[6.0]
-  def change
-    add_column :items, :item, :string
-  end
-end

--- a/db/migrate/20200920040556_add_commits_to_items.rb
+++ b/db/migrate/20200920040556_add_commits_to_items.rb
@@ -1,5 +1,0 @@
-class AddCommitsToItems < ActiveRecord::Migration[6.0]
-  def change
-    add_column :items, :commit, :string
-  end
-end

--- a/db/migrate/20200920043336_remove_item_from_itemss.rb
+++ b/db/migrate/20200920043336_remove_item_from_itemss.rb
@@ -1,5 +1,0 @@
-class RemoveItemFromItemss < ActiveRecord::Migration[6.0]
-  def change
-    remove_column :items, :item, :string
-  end
-end

--- a/db/migrate/20200920043518_remove_item_from_items.rb
+++ b/db/migrate/20200920043518_remove_item_from_items.rb
@@ -1,5 +1,0 @@
-class RemoveItemFromItems < ActiveRecord::Migration[6.0]
-  def change
-    remove_column :items, :commit, :string
-  end
-end

--- a/db/migrate/20200923122921_add_items.rb
+++ b/db/migrate/20200923122921_add_items.rb
@@ -1,0 +1,9 @@
+class AddItems < ActiveRecord::Migration[6.0]
+  def change
+    add_column :items, :category_id,             :integer
+    add_column :items, :days_to_ship_id,         :integer
+    add_column :items, :shipping_area_id,        :integer
+    add_column :items, :shipping_fee_burden_id, :integer
+    add_column :items, :status_id,              :integer
+  end
+end

--- a/db/migrate/20200923122921_add_items.rb
+++ b/db/migrate/20200923122921_add_items.rb
@@ -1,9 +1,0 @@
-class AddItems < ActiveRecord::Migration[6.0]
-  def change
-    add_column :items, :category_id,             :integer
-    add_column :items, :days_to_ship_id,         :integer
-    add_column :items, :shipping_area_id,        :integer
-    add_column :items, :shipping_fee_burden_id, :integer
-    add_column :items, :status_id,              :integer
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_20_043518) do
+ActiveRecord::Schema.define(version: 2020_09_23_122921) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -45,6 +45,11 @@ ActiveRecord::Schema.define(version: 2020_09_20_043518) do
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "category_id"
+    t.integer "days_to_ship_id"
+    t.integer "shipping_area_id"
+    t.integer "shipping_fee_burden_id"
+    t.integer "status_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_23_122921) do
+ActiveRecord::Schema.define(version: 2020_09_17_063023) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -36,20 +36,15 @@ ActiveRecord::Schema.define(version: 2020_09_23_122921) do
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.text "description", null: false
-    t.integer "category", null: false
-    t.integer "status", null: false
+    t.integer "category_id", null: false
+    t.integer "status_id", null: false
     t.integer "price", null: false
-    t.integer "shipping_area", null: false
-    t.integer "shipping_fee_burden", null: false
-    t.integer "days_to_ship", null: false
+    t.integer "shipping_area_id", null: false
+    t.integer "shipping_fee_burden_id", null: false
+    t.integer "days_to_ship_id", null: false
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "category_id"
-    t.integer "days_to_ship_id"
-    t.integer "shipping_area_id"
-    t.integer "shipping_fee_burden_id"
-    t.integer "status_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -3,12 +3,12 @@ FactoryBot.define do
     association :user
     name                  {Faker::Restaurant.name}
     description           {Faker::Restaurant.description}
-    category              {"1"}
-    status                {"1"}
+    category_id              {"1"}
+    status_id                {"1"}
     price                 {"1000"}
-    shipping_area         {"1"}
-    shipping_fee_burden   {"1"}
-    days_to_ship          {"1"}
+    shipping_area_id         {"1"}
+    shipping_fee_burden_id   {"1"}
+    days_to_ship_id          {"1"}
    
     
           

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -16,27 +16,27 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include("Name can't be blank")
       end
       it "カテゴリーの情報が必須であること" do
-        @item.category = "0"
+        @item.category_id = "0"
         @item.valid?
         expect(@item.errors.full_messages).to include("Category is not included in the list")
       end
       it "商品の状態についての情報が必須であること" do
-        @item.status = "0"
+        @item.status_id = "0"
         @item.valid?
         expect(@item.errors.full_messages).to include("Status is not included in the list")
       end
       it "配送料の負担についての情報が必須であること" do
-        @item.shipping_fee_burden = "0"
+        @item.shipping_fee_burden_id = "0"
         @item.valid?
         expect(@item.errors.full_messages).to include("Shipping fee burden is not included in the list")
       end
       it "発送元の地域についての情報が必須であること" do
-        @item.shipping_area = "0"
+        @item.shipping_area_id = "0"
         @item.valid?
         expect(@item.errors.full_messages).to include("Shipping area is not included in the list")
       end
       it "発送までの日数についての情報が必須であること" do
-        @item.days_to_ship = "0"
+        @item.days_to_ship_id = "0"
         @item.valid?
         expect(@item.errors.full_messages).to include("Days to ship is not included in the list")
       end
@@ -63,6 +63,3 @@ RSpec.describe Item, type: :model do
     end
   end
 end
-
-
-#ログインしているユーザーだけが、出品ページへ遷移できること


### PR DESCRIPTION
# WHAT
商品詳細表示機能の実装
# WHY
最終課題フリマアプリ機能実装の為。

- 商品が売れているかどうかで表示する'soldout画像'と'購入画面に進む'は、購入機能実装が終わった後に実装します。該当するコメントアウトはそのままにしています。
## gyazoリンク
ボタンの表示を修正したので動画上げます（沢山すみません）。
ログインして他人が出品した詳細表示画面動画(再修正後）
https://gyazo.com/5681b42d202cd5e6e3f28e51e1e0fddf
ログインして本人が出品した詳細表示画面動画(再修正後）
https://gyazo.com/feaf9fb147697d9d65026b53eeba8980
ログアウト時詳細表示画面動画
https://gyazo.com/573e7f66b382e8866d7393974fa572c5

>出品者の記述を変更したので念のため動画上げます。
> ログインして他人が出品した詳細表示画面動画(修正後）
> https://gyazo.com/b05b453abd8b51933f6237a1b5023cbf

> ログインして他人が出品した詳細表示画面動画
> https://gyazo.com/5c7cd9bb9f8059edac3ae835048c2044
> ログインして本人が出品した詳細表示画面動画
> https://gyazo.com/cf36227aacf46e835d2741087df83bbb
> Itemテーブルテストコード実施後ターミナル画像(内容は前工程と同じです)
> https://gyazo.com/a54ed239d9aa84d281195f96139056d0



