### PR TITLE
カード購入情報を使った購入の実装

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,6 +1,5 @@
 class CardsController < ApplicationController
  
-
   def new
   end
 
@@ -8,10 +7,11 @@ class CardsController < ApplicationController
     Payjp.api_key = ENV["PAYJP_SECRET_KEY"] 
     customer = Payjp::Customer.create(
     description: 'test', 
-    card: params[:token] 
+    card: params[:card_token] 
     )
+
     card = Card.new( 
-      card_token: params[:token], 
+      card_token: params[:card_token], 
       customer_token: customer.id, 
       user_id: current_user.id 
     )
@@ -22,7 +22,7 @@ class CardsController < ApplicationController
       render :new
     end
   end
+
+
   
-
-
 end

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -19,7 +19,7 @@ const pay = ()=> {
       if (status === 200) {
         const token = response.id;
         const renderDom = document.getElementById("charge-form");
-        const tokenObj = `<input value=${token} type="hidden" name='token'>`;
+        const tokenObj = `<input value=${token} type="hidden" name='card_token'>`;
         renderDom.insertAdjacentHTML("beforeend", tokenObj);
      
       document.getElementById("number").removeAttribute("name");

--- a/app/models/purchase_shipping_address.rb
+++ b/app/models/purchase_shipping_address.rb
@@ -2,13 +2,13 @@ class PurchaseShippingAddress
   
   include ActiveModel::Model
 
-  attr_accessor  :postal_code, :shipping_area_id, :city, :address, :building_name, :phone_number, :user_id, :item_id, :token, :purchase_id
+  attr_accessor  :postal_code, :shipping_area_id, :city, :address, :building_name, :phone_number, :user_id, :item_id, :purchase_id
 
   with_options presence: true do
     validates :postal_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "が空です  ハイフン(-)を含めてください"}
     validates :phone_number, format: {with: /\A[0-9]{9,11}\z/, message: "が空です  11文字以内で入力してください ハイフン(-)を入れないで下さい"}
     validates :shipping_area_id, numericality: {other_than: 0}
-    validates :city, :address, :phone_number, :token
+    validates :city, :address, :phone_number
   end
  
   def save

--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -1,4 +1,4 @@
 class ShippingAddress < ApplicationRecord
   belongs_to :purchase
-  
+  belongs_to :card
 end

--- a/app/views/cards/new.html.erb
+++ b/app/views/cards/new.html.erb
@@ -1,14 +1,13 @@
 <%= render "shared/second-header"%>
 
 <%= form_with url: cards_path, id: 'charge-form', class: 'registration-main', local: true do |f| %>
+
 <div class='form-wrap'>
   <div class='form-header'>
     <h1 class='form-header-text'>
       カード登録
     </h1>
   </div>
-
-  <%#= render 'shared/error_messages', model: f.object  %>
 
   <div class="form-group">
     <div class='form-text-wrap'>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,7 +1,6 @@
 <div class="items-sell-contents">
 
   <header class="items-sell-header">
-   <%= javascript_pack_tag 'keisan' %>
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
 
   </header>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -36,7 +36,7 @@
 
       <% unless current_user.id == @item.user_id%>
         <% unless  Purchase.where(item_id: @item.id).present? %>
-          <%= link_to '購入画面に進む', item_purchases_path(@item.id),class:"item-red-btn"%>
+          <%= link_to '購入画面に進む', new_item_purchase_path(@item.id),class:"item-red-btn"%>
         <% end %>
       <% end %>
   <% end %>

--- a/app/views/purchases/new.html.erb
+++ b/app/views/purchases/new.html.erb
@@ -30,46 +30,8 @@
       </p>
     </div>
 
-    <%= form_with model: @purchase,  url: item_purchases_path,  id: "charge-form", class: 'transaction-form-wrap',local: true do |f| %>
+    <%= form_with model: @purchase, url: item_purchases_path, local: true do |f| %>
     <%= render 'shared/error_messages', model: @purchase %> 
-  
-    <div class='credit-card-form'>
-      <h1 class='info-input-haedline'>
-        クレジットカード情報入力
-      </h1>
-      <div class="form-group">
-        <div class='form-text-wrap'>
-          <label class="form-text">カード情報</label>
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.text_field :number, class:"input-default", id:"number", placeholder:"カード番号(半角英数字)", maxlength:"16" %>
-        <div class='available-card'>
-          <%= image_tag 'card-visa.gif', class: 'card-logo'%>
-          <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
-          <%= image_tag 'card-jcb.gif', class: 'card-logo'%>
-          <%= image_tag 'card-amex.gif', class: 'card-logo'%>
-        </div>
-      </div>
-      <div class="form-group">
-        <div class='form-text-wrap'>
-          <label class="form-text">有効期限</label>
-          <span class="indispensable">必須</span>
-        </div>
-        <div class='input-expiration-date-wrap'>
-          <%= f.text_area :exp_month, class:"input-expiration-date", id:"exp_month", placeholder:"例)3" %>
-          <p>月</p>
-          <%= f.text_area :exp_year, class:"input-expiration-date", id:"exp_year", placeholder:"例)23" %>
-          <p>年</p>
-        </div>
-      </div>
-      <div class="form-group">
-        <div class='form-text-wrap'>
-          <label class="form-text">セキュリティコード</label>
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.text_field :cvc, class:"input-default", id:"cvc", placeholder:"カード背面4桁もしくは3桁の番号", maxlength:"4" %>
-      </div>
-    </div>
    
     <div class='shipping-address-form'>
       <h1 class='info-input-haedline'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,9 @@
 Rails.application.routes.draw do
-  get 'cards/new'
   devise_for :users
   resources :items do
-    resources :purchases, only: [:index, :create]
+    resources :purchases, only: [:new, :create]
   end
   resources :users, only: [:show, :update]
   resources :cards, only: [:new, :create]
-  resources :items, only: :order do
-    post 'order', on: :member
-  end
- 
   root to: "items#index"
   end


### PR DESCRIPTION
# WHY

カード情報を登録可能にして購入時の入力の負担を減らす。

# WHAT

カードテーブル作成、useテーブルとリレーション、マイページまたは購入画面（カード情報未登録時）からページ遷移、登録後はマイページにカード情報一部分の表示、購入ページはカード情報＋配送先入力から配送先のみ入力するに変更。